### PR TITLE
[BUGFIX] Filepicker lacks support for file field (yet support inline only)

### DIFF
--- a/Classes/Service/ThumbnailService/ImageThumbnail.php
+++ b/Classes/Service/ThumbnailService/ImageThumbnail.php
@@ -138,11 +138,12 @@ class ImageThumbnail extends \TYPO3\CMS\Media\Service\ThumbnailService
 			}
 		}
 
-		return sprintf('<a href="%s%s" target="%s" data-uid="%s">%s</a>',
+		return sprintf('<a href="%s%s" target="%s" data-uid="%s" data-url="%s">%s</a>',
 			$this->getAnchorUri() ? $this->getAnchorUri() : $file->getPublicUrl(TRUE),
 			$this->getAppendTimeStamp() && !$this->getAnchorUri() ? '?' . $file->getProperty('tstamp') : '',
 			$this->getTarget(),
 			$file->getUid(),
+			$file->getPublicUrl(),
 			$result
 		);
 	}


### PR DESCRIPTION
The FilePicker didn't support file fields but rather only inline fields.

Now it is detecting if the flex form field is a inline relation or file field and based on this another javascript function defined in the core´s formEngine is used to fill in form values.

Since the standard file field uses the files publicUrl as value we had to introduce a data-url attribute on imageViewHelper. Having this attribute on one of the links for a record is enough.

Needless to say that i tested this bugfix on multiple setups and verified inline fields are not broken by this bugfix.

Forge Issue: http://forge.typo3.org/issues/57879
